### PR TITLE
Always enable "next" button after going back to a completed step.

### DIFF
--- a/src/HorizontalStepper.scss
+++ b/src/HorizontalStepper.scss
@@ -57,8 +57,8 @@
       align-items: center;
       justify-content: space-between;
       &.next {
-        border: 2px solid #3383c8;
-        color: #3383c8;
+        border: 2px solid #d80000;
+        color: #d80000;
         right: 1%;
         &.deactivated {
           border: 2px solid #cccccc !important;
@@ -122,7 +122,7 @@
           padding: 0 1rem;
           background-color: white;
           i {
-            background-color: #3383c8;
+            background-color: #d80000;
             color: #fff;
             border-radius: 100rem;
             padding: 1rem;
@@ -171,7 +171,7 @@
       align-items: center;
       justify-content: space-between;
       &.next {
-        background-color: #3383c8;
+        background-color: #d80000;
         color: white;
         @include shadow(1);
         &.deactivated {

--- a/src/HorizontalStepper.vue
+++ b/src/HorizontalStepper.vue
@@ -94,6 +94,10 @@ export default {
     reset: {
       type: Boolean,
       default: false
+    },
+    review: {
+      type: Boolean,
+      default: false
     }
   },
 
@@ -152,8 +156,10 @@ export default {
           this.$emit("completed-step", this.previousStep);
         }
         
-        if(this.steps[index].completed) {
-          this.canContinue = true;
+        if(this.review) {
+            if(this.steps[index].completed) {
+              this.canContinue = true;
+            }
         }
         
       }

--- a/src/HorizontalStepper.vue
+++ b/src/HorizontalStepper.vue
@@ -151,6 +151,11 @@ export default {
         if (!back) {
           this.$emit("completed-step", this.previousStep);
         }
+        
+        if(this.steps[index].completed) {
+          this.canContinue = true;
+        }
+        
       }
       this.$emit("active-step", this.currentStep);
     },


### PR DESCRIPTION
I needed the users to be able to go back to the previous step to give a quick review to their already filled form.
Problem on my app was:
- Vee validate is used to fire the "can-continue" event;
- If the user decides to go back to review the form data and makes no changes, the "next" button is disabled because the "canContinue" variable is set to false again and no event is fired.

I'd like to propose a simple prop for the horizontal-stepper component. 
If set to "true", it always enable the "next" button of a completed step.