### PR TITLE
Remove npm from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "test": "jest"
   },
   "dependencies": {
-    "npm": "^5.10.0",
     "vue": "^2.5.16"
   },
   "jest": {


### PR DESCRIPTION
Having `npm` as dependency brings all alot of packages which has many vulnerabilities. 
But `vue-stepper` package as itself doesn't have this vulnerabilities. I seeing in the code `npm` package didn't have that much of a use.

![image](https://user-images.githubusercontent.com/9023528/61780260-efb0b580-ae21-11e9-86c2-089549f5b096.png)
