### PR TITLE
Add french locale for buttons

### DIFF
--- a/src/Translations.js
+++ b/src/Translations.js
@@ -48,5 +48,10 @@ export default {
         next: 'Nästa',
         back: 'Tillbaka',
         finish: 'Skicka'
+    },
+    fr: {
+        next: 'Suivant',
+        back: 'Précédent',
+        finish: 'Terminé'
     }
 }


### PR DESCRIPTION
So now for french labels of buttons, the `locale` prop should also support `fr` for french